### PR TITLE
Add stub DataMining contract

### DIFF
--- a/contracts/DataCoin.sol
+++ b/contracts/DataCoin.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.18;
 
-import "zeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
+import "zeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
 
-contract DataCoin is StandardToken {
+contract DataCoin is MintableToken {
 
   string public name = "DataCoin";
   string public symbol = "DC";
@@ -10,6 +10,7 @@ contract DataCoin is StandardToken {
   // TODO(rbharath): This is absolutely arbitrary and will likely
   // change.
   uint public INITIAL_SUPPLY = 12000;
+
 
   function DataCoin() public {
     totalSupply_ = INITIAL_SUPPLY;

--- a/contracts/DataMining.sol
+++ b/contracts/DataMining.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.4.18;
+
+import "./DataCoin.sol";
+import "./Validator.sol";
+
+/**
+ * @title DataMining 
+ * @dev DataMining is the contract that controls how new data is mined. 
+ */
+contract DataMining {
+  using SafeMath for uint256;
+
+  // The token being sold
+  DataCoin public datacoin;
+
+  // address where validator stakes are collected
+  address public wallet;
+
+  // TODO(rbharath): This is absolutely arbitrary and will likely
+  // change.
+  // Stake required for validators to be approved.
+  uint public VALIDATOR_STAKE = 100;
+
+  // Contains the list of validators
+  Validator[] public validators;
+
+  /**
+   * event for Validator approval. 
+   * @param validator address of validator approved
+   * @param stake DataCoin placed as stake 
+   */
+  event ValidatorApproval(address indexed validator, uint256 stake);
+
+  function DataMining(address _wallet, DataCoin _datacoin) public {
+    require(_wallet != address(0));
+    require(_datacoin != address(0));
+    wallet = _wallet;
+    datacoin = _datacoin;
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "dotenv": "^4.0.0",
-    "ethjs-abi": "^0.2.1"
+    "ethjs-abi": "^0.2.1",
+    "testrpc": "0.0.1"
   }
 }

--- a/test/TestDataCoin.sol
+++ b/test/TestDataCoin.sol
@@ -6,6 +6,7 @@ contract TestDataCoin {
 
   // Just tests that DataCoin can be instantiated
   function testDataCoinCreation() public {
+    // This address is created in scripts/test.sh
     DataCoin datacoin = new DataCoin();
   }
 }

--- a/test/TestDataMining.sol
+++ b/test/TestDataMining.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.4.18;
+
+import "../contracts/DataCoin.sol";
+import "../contracts/DataMining.sol";
+
+contract TestDataMining {
+
+  // Just tests that DataMining contract can be instantiated
+  function testDataMiningCreation() public {
+    address wallet = address(0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200);
+    DataCoin datacoin = new DataCoin();
+    DataMining datamining = new DataMining(wallet, datacoin);
+  }
+  
+}


### PR DESCRIPTION
Adds a stub contract for DataMining. Modeling this contract off the open-zeppelin `Crowdsale` contract. More work will need to be done before this contract is functional though.

In addition, changes `DataCoin` to inherit from `MintableToken` instead of `StandardToken` since the data mining process will likely mint additional tokens.