### PR TITLE
Validator mocha test

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,7 @@
 var DataCoin = artifacts.require("DataCoin");
+var Validator = artifacts.require("Validator");
 
 module.exports = function(deployer) {
   deployer.deploy(DataCoin);
+  deployer.deploy(Validator);
 }

--- a/test/validator.js
+++ b/test/validator.js
@@ -10,4 +10,4 @@ contract('Validator', function(accounts) {
       assert.equal(owner, accounts[0], "Owner isn't creator of validator");
     });
   });
-});
+}); 

--- a/test/validator.js
+++ b/test/validator.js
@@ -1,0 +1,13 @@
+// Specifically request an abstraction for DataCoin
+var Validator = artifacts.require("Validator");
+
+contract('Validator', function(accounts) {
+  it("Should instantiate validator correctly", function () {
+    // TODO(rbharath): Seems to always deploy at account[0] even if we change to Validator.deployed(accounts[1]). Figure out what's going on.
+    return Validator.deployed(accounts[0]).then(function(instance) {
+      return instance.owner.call();
+    }).then(function(owner) {
+      assert.equal(owner, accounts[0], "Owner isn't creator of validator");
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a simple Mocha test for  the`Validator` contract. It turns out that the `Validator` contract wasn't being migrated properly, so have also modified the deployment file in `migrations/` accordingly.