### PR TITLE
Stub for DataRegistry contract

### DIFF
--- a/contracts/DataMining.sol
+++ b/contracts/DataMining.sol
@@ -6,6 +6,8 @@ import "./Validator.sol";
 /**
  * @title DataMining 
  * @dev DataMining is the contract that controls how new data is mined. 
+ * Note that data mining is the process of having a quorum of
+ * validators authorize acceptance of a new datapoint.
  */
 contract DataMining {
   using SafeMath for uint256;

--- a/contracts/DataRegistry.sol
+++ b/contracts/DataRegistry.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.4.18;
+
+contract DataRegistry {
+
+  // The name of this registry
+  string public name;
+
+  // The address of the owner of this contract
+  address public owner;
+
+  function DataRegistry(string _name) public {
+    owner = msg.sender;
+    name = _name;
+  }
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,7 +1,9 @@
 var DataCoin = artifacts.require("DataCoin");
 var Validator = artifacts.require("Validator");
+var DataRegistry = artifacts.require("DataRegistry");
 
 module.exports = function(deployer) {
   deployer.deploy(DataCoin);
   deployer.deploy(Validator);
+  deployer.deploy(DataRegistry);
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -5,5 +5,5 @@ var DataRegistry = artifacts.require("DataRegistry");
 module.exports = function(deployer) {
   deployer.deploy(DataCoin);
   deployer.deploy(Validator);
-  deployer.deploy(DataRegistry);
+  deployer.deploy(DataRegistry, "TestRegistry");
 }

--- a/test/validator.js
+++ b/test/validator.js
@@ -1,4 +1,4 @@
-// Specifically request an abstraction for DataCoin
+// Specifically request an abstraction for Validator 
 var Validator = artifacts.require("Validator");
 
 contract('Validator', function(accounts) {


### PR DESCRIPTION
This PR adds a stub for the `DataRegistry` contract and adds a simple mocha unit test.

Need to tie into other contracts in future PRs.