### PR TITLE
Test for validator vote

### DIFF
--- a/contracts/Validator.sol
+++ b/contracts/Validator.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.4.18;
 contract Validator {
 
   address public owner;
+  // TODO(rbharath): A vote should be w.r.t a particular DataRegistry
+  // and a particular datapoint. This probably requires a vote to be
+  // a struct with this information.
   string[] public votes;
 
   function Validator() public {

--- a/test/validator.js
+++ b/test/validator.js
@@ -3,11 +3,27 @@ var Validator = artifacts.require("Validator");
 
 contract('Validator', function(accounts) {
   it("Should instantiate validator correctly", function () {
-    // TODO(rbharath): Seems to always deploy at account[0] even if we change to Validator.deployed(accounts[1]). Figure out what's going on.
+    // TODO(rbharath): Seems to always deploy at account[0] even if
+    // we change to Validator.deployed(accounts[1]). Figure out
+    // what's going on.
     return Validator.deployed(accounts[0]).then(function(instance) {
       return instance.owner.call();
     }).then(function(owner) {
       assert.equal(owner, accounts[0], "Owner isn't creator of validator");
     });
   });
+
+  it("Owners should be able to record votes", function () {
+    return Validator.deployed(accounts[0]).then(function(instance) {
+      meta = instance;
+      meta.addVote("hello");
+      return meta;
+    }).then(function(instance) {
+      vote = instance.votes.call(0);
+      return vote; 
+    }).then(function(vote) {
+      assert.equal(vote, "hello");
+    });
+  });
+
 }); 


### PR DESCRIPTION
Adds a simple Mocha test for validators adding votes. This is mostly interesting since it provides an example of using Mocha to to test the behavior of a more complex function (the tests so far only test that `owner` is set correctly).