### PR TITLE
Eslint and Solium Support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,51 @@
+{
+  "extends" : [
+    "standard",
+    "plugin:promise/recommended"
+  ],
+  "plugins": [
+    "promise"
+  ],
+  "env": {
+    "browser" : true,
+    "node"    : true,
+    "mocha"   : true,
+    "jest"    : true
+  },
+  "globals" : {
+    "artifacts": false,
+    "contract": false,
+    "assert": false,
+    "web3": false
+  },
+  "rules": {
+
+    // Strict mode
+    "strict": [2, "global"],
+
+    // Code style
+    "indent": [2, 2],
+    "quotes": [2, "single"],
+    "semi": ["error", "always"],
+    "space-before-function-paren": ["error", "always"],
+    "no-use-before-define": 0,
+    "eqeqeq": [2, "smart"],
+    "dot-notation": [2, {"allowKeywords": true, "allowPattern": ""}],
+    "no-redeclare": [2, {"builtinGlobals": true}],
+    "no-trailing-spaces": [2, { "skipBlankLines": true }],
+    "eol-last": 1,
+    "comma-spacing": [2, {"before": false, "after": true}],
+    "camelcase": [2, {"properties": "always"}],
+    "no-mixed-spaces-and-tabs": [2, "smart-tabs"],
+    "comma-dangle": [1, "always-multiline"],
+    "no-dupe-args": 2,
+    "no-dupe-keys": 2,
+    "no-debugger": 0,
+    "no-undef": 2,
+    "object-curly-spacing": [2, "always"],
+    "max-len": [2, 120, 2],
+    "generator-star-spacing": ["error", "before"],
+    "promise/avoid-new": 0,
+    "promise/always-return": 0
+  }
+}

--- a/.soliumignore
+++ b/.soliumignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": "solium:all",
+  "plugins": ["security"],
+  "rules": {
+    "quotes": ["error", "double"],
+    "indentation": ["error", 2],
+    "arg-overflow": ["warning", 3],
+    "security/enforce-explicit-visibility": ["error"],
+    "security/no-block-members": ["warning"],
+    "security/no-inline-assembly": ["warning"]
+  }
+}

--- a/contracts/DataCoin.sol
+++ b/contracts/DataCoin.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.18;
 //import "zeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
 import "zeppelin-solidity/contracts/token/ERC20/BasicToken.sol";
 
-//contract DataCoin is MintableToken {
+
 contract DataCoin is BasicToken {
 
   string public name = "DataCoin";
@@ -15,6 +15,7 @@ contract DataCoin is BasicToken {
 
   function DataCoin() public {
     balances[msg.sender] = INITIAL_SUPPLY;
+    totalSupply_ = INITIAL_SUPPLY;
   }
 
 }

--- a/contracts/DataMining.sol
+++ b/contracts/DataMining.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.18;
 import "./DataCoin.sol";
 import "./Validator.sol";
 
+
 /**
  * @title DataMining 
  * @dev DataMining is the contract that controls how new data is mined. 
@@ -21,7 +22,7 @@ contract DataMining {
   // TODO(rbharath): This is absolutely arbitrary and will likely
   // change.
   // Stake required for validators to be approved.
-  uint public VALIDATOR_STAKE = 100;
+  uint256 validatorStake_ = 100;
 
   // Contains the list of validators
   Validator[] public validators;
@@ -38,6 +39,13 @@ contract DataMining {
     require(_datacoin != address(0));
     wallet = _wallet;
     datacoin = _datacoin;
+  }
+
+  /**
+  * @dev stake required for validators 
+  */
+  function validatorStake() public view returns (uint256) {
+    return validatorStake_;
   }
 
 }

--- a/contracts/DataRegistry.sol
+++ b/contracts/DataRegistry.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.18;
 
+
 contract DataRegistry {
 
   // The name of this registry

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,11 +1,14 @@
 pragma solidity ^0.4.18;
 
+
 contract Migrations {
   address public owner;
   uint public last_completed_migration;
 
   modifier restricted() {
-    if (msg.sender == owner) _;
+    if (msg.sender == owner) {
+      _;
+    }
   }
 
   function Migrations() public {
@@ -16,8 +19,8 @@ contract Migrations {
     last_completed_migration = completed;
   }
 
-  function upgrade(address new_address) public restricted {
-    Migrations upgraded = Migrations(new_address);
+  function upgrade(address newAddress) public restricted {
+    Migrations upgraded = Migrations(newAddress);
     upgraded.setCompleted(last_completed_migration);
   }
 }

--- a/contracts/Validator.sol
+++ b/contracts/Validator.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.18;
 
+
 contract Validator {
 
   address public owner;

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,5 +1,5 @@
-var Migrations = artifacts.require("./Migrations.sol");
+var Migrations = artifacts.require('./Migrations.sol');
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
   deployer.deploy(Migrations);
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,9 +1,9 @@
-var DataCoin = artifacts.require("DataCoin");
-var Validator = artifacts.require("Validator");
-var DataRegistry = artifacts.require("DataRegistry");
+var DataCoin = artifacts.require('DataCoin');
+var Validator = artifacts.require('Validator');
+var DataRegistry = artifacts.require('DataRegistry');
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
   deployer.deploy(DataCoin);
   deployer.deploy(Validator);
-  deployer.deploy(DataRegistry, "TestRegistry");
-}
+  deployer.deploy(DataRegistry, 'TestRegistry');
+};

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "Contracts implementing Computable Protocol",
   "scripts": {
     "test": "scripts/test.sh",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "lint:sol": "solium -d .",
+    "lint:sol:fix": "solium -d . --fix",
+    "lint:all": "npm run lint && npm run lint:sol",
+    "lint:all:fix": "npm run lint:fix && npm run lint:sol:fix",
     "console": "truffle console",
     "coverage": "scripts/coverage.sh"
   },

--- a/test/TestDataCoin.sol
+++ b/test/TestDataCoin.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.4.18;
 
+import "truffle/Assert.sol";
 import "../contracts/DataCoin.sol";
+
 
 contract TestDataCoin {
 
@@ -8,5 +10,7 @@ contract TestDataCoin {
   function testDataCoinCreation() public {
     // This address is created in scripts/test.sh
     DataCoin datacoin = new DataCoin();
+    uint256 totalSupply = datacoin.totalSupply();
+    Assert.equal(totalSupply, 10000, "Total supply should be 10000");
   }
 }

--- a/test/TestDataMining.sol
+++ b/test/TestDataMining.sol
@@ -1,7 +1,9 @@
 pragma solidity ^0.4.18;
 
+import "truffle/Assert.sol";
 import "../contracts/DataCoin.sol";
 import "../contracts/DataMining.sol";
+
 
 contract TestDataMining {
 
@@ -10,6 +12,7 @@ contract TestDataMining {
     address wallet = address(0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200);
     DataCoin datacoin = new DataCoin();
     DataMining datamining = new DataMining(wallet, datacoin);
+    Assert.equal(datamining.validatorStake(), 100, "Validator stake should be 100");
   }
   
 }

--- a/test/TestValidator.sol
+++ b/test/TestValidator.sol
@@ -4,6 +4,7 @@ import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";
 import "../contracts/Validator.sol";
 
+
 contract TestValidator {
 
   // Just tests that validator can be instantiated

--- a/test/datacoin.js
+++ b/test/datacoin.js
@@ -1,47 +1,51 @@
 // Specifically request an abstraction for DataCoin
-var DataCoin = artifacts.require("DataCoin");
+var DataCoin = artifacts.require('DataCoin');
 
-contract('DataCoin', function(accounts) {
-  it("should put 10000 DataCoin in the first account", function() {
-    return DataCoin.deployed(accounts[0]).then(function(instance) {
+contract('DataCoin', function (accounts) {
+  it('should put 10000 DataCoin in the first account', function () {
+    return DataCoin.deployed(accounts[0]).then(function (instance) {
       return instance.balanceOf.call(accounts[0]);
-    }).then(function(balance) {
-      assert.equal(balance.valueOf(), 10000, "10000 wasn't in the first account");
+    }).then(function (balance) {
+      assert.equal(balance.valueOf(), 10000, '10000 wasn\'t in the first account');
     });
   });
-  it("should send coin correctly", function() {
+  it('should send coin correctly', function () {
     var data;
 
     // Get initial balances of first and second account.
-    var account_one = accounts[0];
-    var account_two = accounts[1];
+    var accountOne = accounts[0];
+    var accountTwo = accounts[1];
 
-    var account_one_starting_balance;
-    var account_two_starting_balance;
-    var account_one_ending_balance;
-    var account_two_ending_balance;
+    var accountOneStartingBalance;
+    var accountTwoStartingBalance;
+    var accountOneEndingBalance;
+    var accountTwoEndingBalance;
 
     var amount = 10;
 
-    return DataCoin.deployed().then(function(instance) {
+    return DataCoin.deployed().then(function (instance) {
       data = instance;
-      return data.balanceOf.call(account_one);
-    }).then(function(balance) {
-      account_one_starting_balance = balance.toNumber();
-      return data.balanceOf.call(account_two);
-    }).then(function(balance) {
-      account_two_starting_balance = balance.toNumber();
-      return data.transfer(account_two, amount, {from: account_one});
-    }).then(function() {
-      return data.balanceOf.call(account_one);
-    }).then(function(balance) {
-      account_one_ending_balance = balance.toNumber();
-      return data.balanceOf.call(account_two);
-    }).then(function(balance) {
-      account_two_ending_balance = balance.toNumber();
+      return data.balanceOf.call(accountOne);
+    }).then(function (balance) {
+      accountOneStartingBalance = balance.toNumber();
+      return data.balanceOf.call(accountTwo);
+    }).then(function (balance) {
+      accountTwoStartingBalance = balance.toNumber();
+      return data.transfer(accountTwo, amount, { from: accountOne });
+    }).then(function () {
+      return data.balanceOf.call(accountOne);
+    }).then(function (balance) {
+      accountOneEndingBalance = balance.toNumber();
+      return data.balanceOf.call(accountTwo);
+    }).then(function (balance) {
+      accountTwoEndingBalance = balance.toNumber();
 
-      assert.equal(account_one_ending_balance, account_one_starting_balance - amount, "Amount wasn't correctly taken from the sender");
-      assert.equal(account_two_ending_balance, account_two_starting_balance + amount, "Amount wasn't correctly sent to the receiver");
+      assert.equal(accountOneEndingBalance,
+        accountOneStartingBalance - amount,
+        'Amount wasn\'t correctly taken from the sender');
+      assert.equal(accountTwoEndingBalance,
+        accountTwoStartingBalance + amount,
+        'Amount wasn\'t correctly sent to the receiver');
     });
   });
 });

--- a/test/dataregistry.js
+++ b/test/dataregistry.js
@@ -1,13 +1,12 @@
 // request abstraction for DataRegistry
-var DataRegistry = artifacts.require("DataRegistry");
+var DataRegistry = artifacts.require('DataRegistry');
 
-contract("DataRegistry", function(accounts) {
-  it("Should instantiate DataRegistry correctly", function () {
-    return DataRegistry.deployed(accounts[0]).then(function(instance) {
+contract('DataRegistry', function (accounts) {
+  it('Should instantiate DataRegistry correctly', function () {
+    return DataRegistry.deployed(accounts[0]).then(function (instance) {
       return instance.owner.call();
-    }).then(function(owner) {
-      assert.equal(owner, accounts[0], "Owner isn't creator of DataRegistry");
+    }).then(function (owner) {
+      assert.equal(owner, accounts[0], 'Owner isn\'t creator of DataRegistry');
     });
   });
 });
-

--- a/test/validator.js
+++ b/test/validator.js
@@ -1,29 +1,28 @@
-// Specifically request an abstraction for Validator 
-var Validator = artifacts.require("Validator");
+// Specifically request an abstraction for Validator
+var Validator = artifacts.require('Validator');
 
-contract('Validator', function(accounts) {
-  it("Should instantiate validator correctly", function () {
+contract('Validator', function (accounts) {
+  it('Should instantiate validator correctly', function () {
     // TODO(rbharath): Seems to always deploy at account[0] even if
     // we change to Validator.deployed(accounts[1]). Figure out
     // what's going on.
-    return Validator.deployed(accounts[0]).then(function(instance) {
+    return Validator.deployed(accounts[0]).then(function (instance) {
       return instance.owner.call();
-    }).then(function(owner) {
-      assert.equal(owner, accounts[0], "Owner isn't creator of validator");
+    }).then(function (owner) {
+      assert.equal(owner, accounts[0], 'Owner isn\'t creator of validator');
     });
   });
 
-  it("Owners should be able to record votes", function () {
-    return Validator.deployed(accounts[0]).then(function(instance) {
+  it('Owners should be able to record votes', function () {
+    return Validator.deployed(accounts[0]).then(function (instance) {
       var meta = instance;
-      meta.addVote("hello");
+      meta.addVote('hello');
       return meta;
-    }).then(function(instance) {
+    }).then(function (instance) {
       var vote = instance.votes.call(0);
-      return vote; 
-    }).then(function(vote) {
-      assert.equal(vote, "hello");
+      return vote;
+    }).then(function (vote) {
+      assert.equal(vote, 'hello');
     });
   });
-
-}); 
+});


### PR DESCRIPTION
Following https://github.com/OpenZeppelin/zeppelin-solidity, this PR adds support for `eslint` and `solium` to this repo. `eslint` is a linter for javascript, and `solium` is a solidity linter. The `package.json` file was modified to add the following new commands:

- `npm run lint`
- `npm run lint:fix`
- `npm run lint:sol`
- `npm run lint:sol:fix`
- `npm run lint:all`
- `npm run lint:all:fix`

Which run `eslint` and `solium` and their autofix features. In addition, this PR modifies all our javascript and contract files so that they pass lint. Moving forward, all contracts will need to pass lint in order to be merged into the repo.