### PR TITLE
Enables Coverage Tests

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,9 @@
+module.exports = {
+    norpc: true,
+    testCommand: 'node --max-old-space-size=4096 ../node_modules/.bin/truffle test --network coverage',
+    compileCommand: 'node --max-old-space-size=4096 ../node_modules/.bin/truffle compile --network coverage',
+    skipFiles: [
+        'lifecycle/Migrations.sol',
+        'mocks'
+    ]
+}

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,4 +1,5 @@
 module.exports = {
+    copyPackages: ['zeppelin-solidity'],
     norpc: true,
     testCommand: 'node --max-old-space-size=4096 ../node_modules/.bin/truffle test --network coverage',
     compileCommand: 'node --max-old-space-size=4096 ../node_modules/.bin/truffle compile --network coverage',


### PR DESCRIPTION
This PR enables running of coverage tests. Coverage checks what fraction of the lines in our solidity contracts have tests covering them and uses the https://github.com/sc-forks/solidity-coverage package to do so. The following new command has been added:

- `npm run coverage`

Which generates very nice reports:

![image](https://user-images.githubusercontent.com/1057676/36455690-1e2f205a-1656-11e8-9e74-6717a84a9a16.png)
